### PR TITLE
fix: clear autoname override + route uniqueness

### DIFF
--- a/erpnext_feature_board/erpnext_feature_board/doctype/github_repository/github_repository.py
+++ b/erpnext_feature_board/erpnext_feature_board/doctype/github_repository/github_repository.py
@@ -80,6 +80,8 @@ def update_improvement(pull_request: "PullRequest", repository: str):
 		"pull_request_url": pull_request.html_url,
 		"raw_data": json.dumps(pull_request.raw_data),
 		"repository": repository,
+		# create a unique route based on the PR details
+		"route": f"{pull_request.head.repo.name}:{pull_request.number}",
 		"source_branch": pull_request.head.ref,
 		"status": pull_request.state.title(),
 		"target_branch": pull_request.base.ref,

--- a/erpnext_feature_board/erpnext_feature_board/doctype/improvement/improvement.py
+++ b/erpnext_feature_board/erpnext_feature_board/doctype/improvement/improvement.py
@@ -6,4 +6,6 @@ from frappe.website.website_generator import WebsiteGenerator
 
 
 class Improvement(WebsiteGenerator):
-	pass
+	# the WebsiteGenerator class overrides the naming_series in the
+	# doctype definition, overriding the override
+	autoname = "naming_series:"


### PR DESCRIPTION
Closes #3.

Let me know if the route seems unique enough - I've currently set it to `{app_name}-{pr_number}`.